### PR TITLE
add restrict list client

### DIFF
--- a/konduto/api/__init__.py
+++ b/konduto/api/__init__.py
@@ -8,6 +8,7 @@ from requests import Response
 from konduto import VERSION
 from konduto.api.clients import KondutoHttpClient
 from konduto.api.clients.v1.order import OrderClientKonduto
+from konduto.api.clients.v1.restrict_list import RestrictClientKonduto
 from konduto.infrastructure.either import Either, Right, Left
 
 

--- a/konduto/api/clients/v1/order.py
+++ b/konduto/api/clients/v1/order.py
@@ -12,20 +12,9 @@ from konduto.api.resources.requests.order_status_request import OrderStatusReque
 from konduto.api.resources.response.error import Error
 from konduto.api.resources.response.order_response import OrderResponse, Recommendation
 from konduto import KONDUTO_DOMAIN
+from konduto.infrastructure.parsers import datetime_str_to_datetime, float_to_decimal, date_str_to_date
 
 ENDPOINT = f'{KONDUTO_DOMAIN}v1/orders'.strip('/')
-
-
-def _date_str_to_date(date_str):
-    return datetime.strptime(date_str, '%Y-%m-%d').date()
-
-
-def _float_to_decimal(float_number):
-    return Decimal(str(float_number))
-
-
-def _datetime_str_to_datetime(datetime_str):
-    return datetime.strptime(datetime_str, '%Y-%m-%dT%H:%M:%SZ')
 
 
 class OrderClientKonduto(KondutoHttpClient):
@@ -56,8 +45,8 @@ class OrderClientKonduto(KondutoHttpClient):
         if result.is_right:
             return from_dict(data_class=OrderResponse, data=result.value,
                              config=Config(cast=[Enum],
-                                           type_hooks={date: _date_str_to_date,
-                                                       Decimal: _float_to_decimal,
-                                                       datetime: _datetime_str_to_datetime}))
+                                           type_hooks={date: date_str_to_date,
+                                                       Decimal: float_to_decimal,
+                                                       datetime: datetime_str_to_datetime}))
 
         return result.value

--- a/konduto/api/clients/v1/restrict_list.py
+++ b/konduto/api/clients/v1/restrict_list.py
@@ -1,0 +1,48 @@
+from typing import Union
+
+from konduto import KONDUTO_DOMAIN
+from konduto.api import KondutoHttpClient
+from konduto.api.resources.requests.restrict_email_request import RestrictEmailRequest
+from konduto.api.resources.response.error import Error
+from konduto.api.resources.response.restrict_email_response import RestrictEmailResponse, RestrictEmailResponseMapper
+
+ENDPOINT = f'{KONDUTO_DOMAIN}v1/blacklist/email'.strip('/')
+
+
+class RestrictClientKonduto(KondutoHttpClient):
+
+    def create(self, payload: RestrictEmailRequest) -> Union[RestrictEmailResponse, Error]:
+        result = self.post(ENDPOINT, payload.json)
+
+        if result.is_right:
+            return RestrictEmailResponseMapper.to_model(result.value)
+
+        return result.value
+
+    def update(self, email: str, payload: RestrictEmailRequest):
+        result = self.put(f'{ENDPOINT}/{email}', payload.json_to_update)
+
+        if result.is_right:
+            konduto_response = result.value
+            konduto_response['email_address'] = email
+            return RestrictEmailResponseMapper.to_model(konduto_response)
+
+        return result.value
+
+    def load(self, email):
+        result = self.get(f'{ENDPOINT}/{email}')
+
+        if result.is_right:
+            return RestrictEmailResponseMapper.to_model(result.value)
+
+        return result.value
+
+    def remove(self, email: str):
+        result = self.delete(f'{ENDPOINT}/{email}')
+
+        if result.is_right:
+            konduto_response = result.value
+            konduto_response['email_address'] = email
+            return RestrictEmailResponseMapper.to_model(konduto_response)
+
+        return result.value

--- a/konduto/api/resources/requests/restrict_email_request.py
+++ b/konduto/api/resources/requests/restrict_email_request.py
@@ -1,0 +1,21 @@
+import json
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+
+@dataclass
+class RestrictEmailRequest:
+    email_address: str
+    days_to_expire: Optional[int] = None
+
+    @property
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @property
+    def json(self) -> str:
+        return json.dumps(self.to_dict)
+
+    @property
+    def json_to_update(self) -> str:
+        return json.dumps({'days_to_expire': self.days_to_expire})

--- a/konduto/api/resources/response/restrict_email_response.py
+++ b/konduto/api/resources/response/restrict_email_response.py
@@ -1,0 +1,47 @@
+import json
+from dataclasses import dataclass, asdict
+from datetime import date
+from typing import Optional
+
+from konduto.infrastructure.json_enconder import JsonEncoder
+from konduto.infrastructure.parsers import date_str_to_date, datetime_str_to_datetime
+
+
+@dataclass
+class RestrictEmailResponse:
+    expires_at: date
+    uri: Optional[str] = None
+    created_at: Optional[date] = None
+    updated_at: Optional[date] = None
+    email_address: Optional[str] = None
+    message: Optional[str] = None
+
+    @property
+    def email(self):
+        if self.email_address:
+            return self.email_address
+        elif self.uri:
+            self.email_address = str(self.uri).split('/')[-1]
+            return self.email_address
+        else:
+            return None
+
+    @property
+    def to_dict(self):
+        return asdict(self)
+
+    @property
+    def json(self):
+        return json.dumps(self.to_dict, cls=JsonEncoder)
+
+
+class RestrictEmailResponseMapper:
+
+    @staticmethod
+    def to_model(payload: dict) -> RestrictEmailResponse:
+        expires_at = date_str_to_date(payload['expires_at']) if payload.get('expires_at') else None
+        created_at = datetime_str_to_datetime(payload['created_at']) if payload.get('created_at') else None
+        updated_at = datetime_str_to_datetime(payload['updated_at']) if payload.get('updated_at') else None
+        return RestrictEmailResponse(expires_at=expires_at, uri=payload.get('uri'), created_at=created_at,
+                                     updated_at=updated_at, email_address=payload.get('email_address'),
+                                     message=payload.get('message'))

--- a/konduto/client.py
+++ b/konduto/client.py
@@ -20,6 +20,7 @@ class KondutoClient(BaseClient):
     """
 
     order = api.OrderClientKonduto()
+    restrict = api.RestrictClientKonduto()
 
     def __init__(self, private_key: str = None):
         super().__init__(private_key)

--- a/konduto/infrastructure/parsers.py
+++ b/konduto/infrastructure/parsers.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from decimal import Decimal
+
+
+def date_str_to_date(date_str):
+    return datetime.strptime(date_str, '%Y-%m-%d').date()
+
+
+def float_to_decimal(float_number):
+    return Decimal(str(float_number))
+
+
+def datetime_str_to_datetime(datetime_str):
+    return datetime.strptime(datetime_str, '%Y-%m-%dT%H:%M:%SZ')

--- a/tests/api/clients/test_restrict_list_client.py
+++ b/tests/api/clients/test_restrict_list_client.py
@@ -1,0 +1,71 @@
+import json
+
+import requests_mock
+from pytest import fixture
+
+from konduto import KONDUTO_DOMAIN
+from konduto.api.resources.response.restrict_email_response import RestrictEmailResponse
+from konduto.client import KondutoClient
+from tests.fixtures.request_factories import RestrictEmailRequestFactory
+from tests.fixtures.response_factories import RestrictEmailResponseFactory
+
+API_ENDPOINT_MOCK = f'{KONDUTO_DOMAIN}v1/blacklist/email'.strip('/')
+
+
+class TestRestrictListClient:
+
+    @fixture
+    def restrict_client(self):
+        client = KondutoClient(private_key='some-key')
+        return client
+
+    def test_should_create_an_restrict_email(self, restrict_client):
+        email_request = RestrictEmailRequestFactory()
+        email_response = RestrictEmailResponseFactory(email_address=email_request.email_address)
+
+        with requests_mock.mock() as mock:
+            mock.post(API_ENDPOINT_MOCK, text=email_response.json)
+            response = restrict_client.restrict.create(email_request)
+
+            assert response.uri
+            assert response.created_at
+            assert response.expires_at
+            assert response.email == email_request.email_address
+
+    def test_should_return_an_restrict_email(self, restrict_client):
+        expected_email = RestrictEmailRequestFactory().email_address
+        email_response = RestrictEmailResponseFactory(email_address=expected_email)
+
+        with requests_mock.mock() as mock:
+            mock.get(f'{API_ENDPOINT_MOCK}/{expected_email}', text=email_response.json)
+            response = restrict_client.restrict.load(expected_email)
+
+            assert response
+            assert isinstance(response, RestrictEmailResponse)
+            assert response.email == expected_email
+
+    def test_should_update_an_restrict_email(self, restrict_client):
+
+        email_request = RestrictEmailRequestFactory()
+        email_response = RestrictEmailResponseFactory(email_address=email_request.email_address)
+
+        with requests_mock.mock() as mock:
+            mock.put(f'{API_ENDPOINT_MOCK}/{email_request.email_address}', text=email_response.json)
+            response = restrict_client.restrict.update(email_request.email_address, email_request)
+
+            assert response
+            assert isinstance(response, RestrictEmailResponse)
+            assert response.email == email_request.email_address
+
+    def test_should_delete_an_restrict_email(self, restrict_client):
+        expected_email = RestrictEmailRequestFactory().email_address
+        email_response = RestrictEmailResponseFactory(email_address=expected_email)
+
+        with requests_mock.mock() as mock:
+            mock.delete(f'{API_ENDPOINT_MOCK}/{expected_email}', text=email_response.json)
+            response = restrict_client.restrict.remove(expected_email)
+
+            assert response
+            assert isinstance(response, RestrictEmailResponse)
+            assert response.email == expected_email
+            assert response.message

--- a/tests/fixtures/request_factories.py
+++ b/tests/fixtures/request_factories.py
@@ -10,6 +10,7 @@ from konduto.api.resources.billing import Billing
 from konduto.api.resources.customer import Customer
 from konduto.api.resources.payment import Payment, PaymentType, PaymentStatus
 from konduto.api.resources.requests.order_request import OrderRequest
+from konduto.api.resources.requests.restrict_email_request import RestrictEmailRequest
 from konduto.api.resources.seller import Seller
 from konduto.api.resources.shipping import Shipping
 from konduto.api.resources.shopping_cart import Product, ShoppingCart
@@ -121,3 +122,11 @@ class OrderRequestFactory(factory.Factory):
     messages_exchanged = lazy_attribute(lambda o: fake.pyint(min_value=0, max_value=9999, step=5))
     purchased_at = lazy_attribute(lambda o: fake.date_time(tzinfo=None, end_datetime=None))
     seller = SubFactory(SellerFactory)
+
+
+class RestrictEmailRequestFactory(factory.Factory):
+    class Meta:
+        model = RestrictEmailRequest
+
+    email_address = lazy_attribute(lambda o: fake.email())
+    days_to_expire = lazy_attribute(lambda o: fake.pyint(min_value=0, max_value=9999, step=5))

--- a/tests/fixtures/response_factories.py
+++ b/tests/fixtures/response_factories.py
@@ -1,4 +1,3 @@
-import random
 import secrets
 import uuid
 
@@ -8,6 +7,7 @@ from faker import Faker
 
 from konduto.api.resources.order_status import OrderStatus
 from konduto.api.resources.response.order_response import OrderResponse, Recommendation
+from konduto.api.resources.response.restrict_email_response import RestrictEmailResponse
 from tests.fixtures.request_factories import CustomerFactory, BillingFactory, ShippingFactory, PaymentFactory, \
     SellerFactory, ProductFactory
 
@@ -39,3 +39,15 @@ class OrderResponseFactory(factory.Factory):
     messages_exchanged = lazy_attribute(lambda o: fake.pyint(min_value=0, max_value=9999, step=5))
     purchased_at = lazy_attribute(lambda o: fake.date_time(tzinfo=None, end_datetime=None))
     seller = SubFactory(SellerFactory)
+
+
+class RestrictEmailResponseFactory(factory.Factory):
+    class Meta:
+        model = RestrictEmailResponse
+
+    uri = lazy_attribute(lambda o: f'/v1/blacklist/email/{fake.email()}')
+    expires_at = lazy_attribute(lambda o: fake.date_object())
+    created_at = lazy_attribute(lambda o: fake.date_time(tzinfo=None, end_datetime=None))
+    updated_at = lazy_attribute(lambda o: fake.date_time(tzinfo=None, end_datetime=None))
+    email_address = lazy_attribute(lambda o: fake.email())
+    message = lazy_attribute(lambda o: fake.text())


### PR DESCRIPTION
include restrict the client with all operations supported by konduto API, this way is possible to:

1) create a restrict entry
2) update a restrict entry
3) load information from restrict entry
4) remove a restrict entry

The konduto API called this resource as "blacklist" but here I prefer to call for `RestrictList` because the word `blacklist` is a very offensive term and we already have an event to stop the use of these words that can be offensive.

You can read more here: https://www.theregister.co.uk/2019/09/03/chromium_microsoft_offensive/